### PR TITLE
URLの履歴管理、state管理を実装

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,15 +16,10 @@ var Routeful = function() {
   this._base = '/';
   this._root = '';
   this._stack = [];
-  var state = (history.length === 1 || location.pathname === '/') ? history.length - 1 : history.state;
-  this.isLegacy = !this.testStateFormat(state);
   this._history = new Array(history.length);
-  this.state = 0;
-  if (!this.isLegacy) {
-    this.state = state;
-    this._history[state] = location.href.replace(location.origin, '');
-    history.replaceState(state, null, this._history[state]);
-  }
+  this.state = this.testStateFormat(history.state) ? history.state : history.length - 1;
+  this._history[this.state] = location.href.replace(location.origin, '');
+  history.replaceState(this.state, null, this._history[this.state]);
 };
 
 Routeful.prototype.base = function(base) {
@@ -131,7 +126,7 @@ Routeful.prototype.popState = function(state) {
   return this;
 };
 
-Routeful.prototype.getCurrent = function(state) {
+Routeful.prototype.getCurrent = function() {
   return this._current;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -119,8 +119,8 @@ Routeful.prototype.popState = function(state) {
   if (this.isLegacy) {
     return this;
   }
-  this.isBack = this.state < state;
-  this.isForward = this.state > state;
+  this.isBack = this.state > state;
+  this.isForward = this.state < state;
   this.state = state;
   this._history[this.state] = location.href.replace(location.origin, '');
   return this;

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ Routeful.prototype.canForward = function() {
   if (this.isLegacy) {
     return false;
   }
-  return this.state < history.length - 1;
+  return this.state < this._history.length - 1;
 };
 
 var onclick = function(e) {

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ var onpopstate = function(e) {
       this.isForward = false;
     }
   }
-  this.emit(location.pathname + location.hash);
+  this.emit(location.pathname + location.search + location.hash);
 };
 
 module.exports = Routeful;

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,15 @@ var Routeful = function() {
   this._base = '/';
   this._root = '';
   this._stack = [];
+  // 履歴の数だけ、空の配列を生成する
   this._history = new Array(history.length);
+  // 現在のページに history.state が設定されていて、想定のフォーマットならそのまま history.state をセットする
+  // history.state が想定外のフォーマットの場合は、 history.length - 1 を設定する
+  // state は this._history のインデックス
   this.state = this.testStateFormat(history.state) ? history.state : history.length - 1;
+  // 現在のページのURLをキャッシュしておく
   this._history[this.state] = location.href.replace(location.origin, '');
+  // 現在のページに state (index) を設定しておく
   history.replaceState(this.state, null, this._history[this.state]);
 };
 
@@ -61,12 +67,14 @@ Routeful.prototype.go = function(path, replace) {
 
   if (replace === true) {
     history.replaceState(this.state, null, path);
+    // 今のURLを再キャッシュする
     this._history[this.state] = location.href.replace(location.origin, '');
   }
   else {
     history.pushState(this.state + 1, null, path);
     this._pushHistory();
   }
+  // 戻ったか進んだかのフラグを false にする
   this.isBack = false;
   this.isForward = false;
   // query は無視する
@@ -101,6 +109,9 @@ Routeful.prototype.emit = function(path) {
   return this;
 };
 
+/**
+ * 履歴のインデックスを進めて、URLをキャッシュする
+ */
 Routeful.prototype._pushHistory = function() {
   this.state++;
   if (this.state < this._history.length) {
@@ -110,26 +121,42 @@ Routeful.prototype._pushHistory = function() {
   return this;
 };
 
+/**
+ * routeful で想定する、 state のフォーマットかどうか
+ * @param {*} state 
+ */
 Routeful.prototype.testStateFormat = function(state) {
   return typeof state === 'number';
 };
 
 Routeful.prototype.popState = function(state) {
   this.isLegacy = !this.testStateFormat(state);
+  // 想定外のフォーマットの場合は、旧仕様のフラグを立てて、必要最低限の処理のみ実行する
   if (this.isLegacy) {
     return this;
   }
+  // 戻ったフラグ
   this.isBack = this.state > state;
+  // 進んだフラグ
   this.isForward = this.state < state;
+  // state (index) の更新
   this.state = state;
+  // URL をキャッシュ
   this._history[this.state] = location.href.replace(location.origin, '');
   return this;
 };
 
+/**
+ * 現在のページのパスを取得
+ */
 Routeful.prototype.getCurrent = function() {
   return this._current;
 };
 
+/**
+ * 前のページのパスを取得
+ * 取得できない場合は null
+ */
 Routeful.prototype.getPrev = function() {
   if (this.isLegacy) {
     return null;
@@ -141,6 +168,10 @@ Routeful.prototype.getPrev = function() {
   return url.replace(this._root, '').replace(this._base, '/');
 };
 
+/**
+ * 次のページのパスを取得
+ * 取得できない場合は null
+ */
 Routeful.prototype.getNext = function() {
   if (this.isLegacy) {
     return null;
@@ -152,6 +183,9 @@ Routeful.prototype.getNext = function() {
   return url.replace(this._root, '').replace(this._base, '/');
 };
 
+/**
+ * 戻れるかどうか
+ */
 Routeful.prototype.canBack = function() {
   if (this.isLegacy) {
     return false;
@@ -159,6 +193,9 @@ Routeful.prototype.canBack = function() {
   return this.state > 0;
 };
 
+/**
+ * 進めるかどうか
+ */
 Routeful.prototype.canForward = function() {
   if (this.isLegacy) {
     return false;
@@ -200,7 +237,7 @@ var onpopstate = function(e) {
     this.popState(e.state);
   }
   else if (e.type === 'hashchange') {
-    // location.hash = 'xxx' で変更した場合
+    // location.hash = 'xxx' で変更した場合は、 go で pushState した後と同じ状態になるように処理する
     if (!this.isLegacy && !this.testStateFormat(history.state)) {
       this._pushHistory();
       this.isBack = false;


### PR DESCRIPTION
- state は現在のページの this._history に対してのインデックス
- this._history.length は history.length と同じ数値になることを想定している
- canBack : 戻れるかどうかの判定
- canForward : 進めるかどうかの判定
- getPrev : 前のページのpathを返す。返せない場合は null
- getNext : 次のページのpathを返す。返せない場合は null
- popState : onpopstate でURLとstateが更新されたときに、routefulの状態も更新する
- state が想定外の場合は、 isLegacy フラグを立てて、今回実装した機能の処理をしないようにする
- 最初にアクセスしたページはstateがnullになるので、replaceState で最適な数値に変更している
- popstate で戻った場合はisBack、進んだ場合は isForward

## 想定されるバグ
別のサイトからこの機能を実装したページへブラウザバックを使用して遷移した際に、stateがnullの場合、戻れなくても canBack がtrueになる可能性がある (理論上起こることはあるが再現したことはない)
